### PR TITLE
Change function visibility from public to internal and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,31 +22,31 @@ library Base58 {
     * @param data_ raw data, passed in as bytes.
     * @return base58 encoded data_, returned as bytes.
     */
-    function encode(bytes memory data_) public pure returns (bytes memory);
+    function encode(bytes memory data_) internal pure returns (bytes memory);
     /**
     * @notice decode is used to decode the given string in base58 standard.
     * @param data_ data encoded with base58, passed in as bytes.
     * @return raw data, returned as bytes.
     */
-    function decode(bytes memory data_) public pure returns (bytes memory)
+    function decode(bytes memory data_) internal pure returns (bytes memory)
     /**
     * @notice encodeToString is used to encode the given byte in base58 standard.
     * @param data_ raw data, passed in as bytes.
     * @return base58 encoded data_, returned as a string.
     */
-    function encodeToString(bytes memory data_) public pure returns (string memory)
+    function encodeToString(bytes memory data_) internal pure returns (string memory)
     /**
     * @notice encodeFromString is used to encode the given string in base58 standard.
     * @param data_ raw data, passed in as a string.
     * @return base58 encoded data_, returned as bytes.
     */
-    function encodeFromString(string memory data_) public pure returns (bytes memory)
+    function encodeFromString(string memory data_) internal pure returns (bytes memory)
     /**
     * @notice decode is used to decode the given string in base58 standard.
     * @param data_ data encoded with base58, passed in as string.
     * @return raw data, returned as bytes.
     */
-    function decodeFromString(string memory data_) public pure returns (bytes memory)
+    function decodeFromString(string memory data_) internal pure returns (bytes memory)
 }
 ```
 
@@ -56,7 +56,7 @@ library Base58 {
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.20;
 
 import "base58-solidity/contracts/Base58.sol";
 

--- a/contracts/Base58.sol
+++ b/contracts/Base58.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.7;
+pragma solidity ^0.8.20;
 
 /**
  * @title Base58
@@ -16,7 +16,7 @@ library Base58 {
      * @param data_ raw data, passed in as bytes.
      * @return base58 encoded data_, returned as bytes.
      */
-    function encode(bytes memory data_) public pure returns (bytes memory) {
+    function encode(bytes memory data_) internal pure returns (bytes memory) {
         unchecked {
             uint256 size = data_.length;
             uint256 zeroCount;
@@ -54,7 +54,7 @@ library Base58 {
      * @param data_ data encoded with base58, passed in as bytes.
      * @return raw data, returned as bytes.
      */
-    function decode(bytes memory data_) public pure returns (bytes memory) {
+    function decode(bytes memory data_) internal pure returns (bytes memory) {
         unchecked {
             uint256 zero = 49;
             uint256 b58sz = data_.length;
@@ -108,7 +108,7 @@ library Base58 {
      * @param data_ raw data, passed in as bytes.
      * @return base58 encoded data_, returned as a string.
      */
-    function encodeToString(bytes memory data_) public pure returns (string memory) {
+    function encodeToString(bytes memory data_) internal pure returns (string memory) {
         return string(encode(data_));
     }
 
@@ -118,7 +118,7 @@ library Base58 {
      * @return base58 encoded data_, returned as bytes.
      */
     function encodeFromString(string memory data_)
-        public
+        internal
         pure
         returns (bytes memory)
     {
@@ -131,7 +131,7 @@ library Base58 {
      * @return raw data, returned as bytes.
      */
     function decodeFromString(string memory data_)
-        public
+        internal
         pure
         returns (bytes memory)
     {
@@ -149,7 +149,7 @@ library Base58 {
         bytes memory data_,
         uint256 start_,
         uint256 end_
-    ) public pure returns (bytes memory) {
+    ) internal pure returns (bytes memory) {
         unchecked {
             bytes memory ret = new bytes(end_ - start_);
             for (uint256 i = 0; i < end_ - start_; i++) {
@@ -166,7 +166,7 @@ library Base58 {
      * @return index, and whether the search was successful.
      */
     function indexOf(bytes memory data_, bytes1 char_)
-        public
+        internal
         pure
         returns (uint256, bool)
     {

--- a/contracts/Base58Helper.sol
+++ b/contracts/Base58Helper.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./Base58.sol";
+
+contract Base58Helper {
+
+    function encodeToString(bytes memory data_)
+        public
+        pure
+        returns (string memory)
+    {
+        return Base58.encodeToString(data_);
+    }
+
+
+    function decodeFromString(string memory data_)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return Base58.decodeFromString(data_);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,11 +1,11 @@
-require("@nomiclabs/hardhat-ethers");
+require("@nomicfoundation/hardhat-toolbox");
 
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
     solidity: {
-        version: "0.8.7",
+        version: "0.8.20",
         settings: {
             optimizer: {
                 enabled: true,

--- a/package.json
+++ b/package.json
@@ -17,12 +17,10 @@
 	},
   "license": "MIT",
   "devDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.0.5",
-    "ethers": "^5.6.2"
+    "@nomicfoundation/hardhat-toolbox": "^5.0.0"
   },
   "dependencies": {
-    "chai": "^4.3.6",
-    "hardhat": "^2.9.3"
+    "hardhat": "^2.22.5"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/test/Base58.js
+++ b/test/Base58.js
@@ -2,14 +2,13 @@
 // so feel free to add new ones.
 
 // Hardhat tests are normally written with Mocha and Chai.
-
-// We import Chai to use its asserting functions here.
 const { expect } = require("chai");
 
 // We use `loadFixture` to share common setups (or fixtures) between tests.
 // Using this simplifies your tests and makes them run faster, by taking
 // advantage of Hardhat Network's snapshot functionality.
-const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { loadFixture } = require("@nomicfoundation/hardhat-toolbox/network-helpers");
+const { ethers} = require("hardhat");
 
 // `describe` is a Mocha function that allows you to organize your tests.
 // Having your tests organized makes debugging them easier. All Mocha
@@ -18,14 +17,14 @@ const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
 // `describe` receives the name of a section of your test suite, and a
 // callback. The callback must define the tests of that section. This callback
 // can't be an async function.
-describe("Base58", function () {
+describe("Base58", () => {
     // We define a fixture to reuse the same setup in every test. We use
     // loadFixture to run this setup once, snapshot that state, and reset Hardhat
     // Network to that snapshopt in every test.
     async function deployBase58() {
         // Get the ContractFactory and Signers here.
         const contractFactory = await ethers.getContractFactory(
-            "contracts/Base58.sol:Base58"
+            "contracts/Base58Helper.sol:Base58Helper"
         );
         const [owner] = await ethers.getSigners();
 
@@ -34,14 +33,14 @@ describe("Base58", function () {
         // mined.
         const contract = await contractFactory.deploy();
 
-        await contract.deployed();
+        await contract.waitForDeployment();
 
         // Fixtures can return anything you consider useful for your tests
         return { contractFactory, contract, owner };
     }
 
     // You can nest describe calls to create subsections.
-    describe("Encode/Decode", function () {
+    describe("Encode/Decode", () => {
         const testCases = [
             {
                 input: "0x52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649",
@@ -807,7 +806,7 @@ describe("Base58", function () {
                 output: "Ru8wQDcPgkiU3Jo3WnAt4cpHyjTRLXYcBcNpiKwapEhQGbef6vRxFDaTA5htW6WXw2N9Awm1fWPrSMC2vN2qmjn4jr5aA1grgpDKL5oa9C8bUvtHhVbQqimF4H5naQBX37kqGSF",
             },
         ];
-        it("Should able to encode", async function () {
+        it("Should able to encode", async () => {
             const { contract, owner } = await loadFixture(deployBase58);
             for (const item of testCases) {
                 expect(await contract.encodeToString(item.input)).to.equal(
@@ -815,7 +814,7 @@ describe("Base58", function () {
                 );
             }
         });
-        it("Should able to decode", async function () {
+        it("Should able to decode", async () => {
             const { contract, owner } = await loadFixture(deployBase58);
             for (const item of testCases) {
                 expect(await contract.decodeFromString(item.output)).to.equal(


### PR DESCRIPTION
### Changes

1. **Change Library Function Visibility:**
   - Changed the visibility of library functions from `public` to `internal`.
   - Previously, using library functions required a separate deployment process for the library along with the contracts that used it.
   - With this change, the library functions can be used in other contracts without needing to deploy the library separately.

2. **Dependency Updates:**
   - Upgraded the Hardhat version.
   - Updated various utilities to use the `@nomicfoundation/hardhat-toolbox` dependency.

### Reason

- The visibility change improves the ease of using library functions within other contracts.
- Upgrading to the latest version of Hardhat and utilities enhances the project's stability and functionality.

### Testing

- Verified that all existing test cases pass successfully.